### PR TITLE
fix(agents): make stub_llm_response deterministic across processes

### DIFF
--- a/agents/retail_ai.py
+++ b/agents/retail_ai.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import os
 import numpy as np
 from dataclasses import dataclass
+import hashlib
 from enum import Enum
 from typing import Optional
 
@@ -42,6 +43,18 @@ class InvestorType(Enum):
     MEME_TRADER     = "meme_trader"      # social-media driven, asks about short interest
 
 
+def stable_seed(text: str, salt: int = 0) -> int:
+    """
+    Process-stable 32-bit seed derived from a string.
+
+    Python randomizes builtin hash() of str per process (PEP 456), so seeding
+    an RNG from it makes results irreproducible across interpreter launches.
+    SHA-256 is stable across processes, machines, and Python versions.
+    """
+    digest = hashlib.sha256(f"{salt}:{text}".encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], "big")
+
+
 @dataclass
 class RetailQuery:
     """A single retail investor's AI query at time t."""
@@ -49,6 +62,7 @@ class RetailQuery:
     tickers: list[str]
     context: str      # natural language context (earnings, news, etc.)
     risk_tolerance: float  # 0=very conservative, 1=very aggressive
+    seed: int | None = None  # explicit seed; falls back to stable_seed(context)
 
 
 def simulate_retail_query_distribution(
@@ -145,7 +159,8 @@ def stub_llm_response(
     ticker_to_idx = {t: i for i, t in enumerate(tickers)}
     alloc = np.zeros(n)
 
-    rng = np.random.default_rng(abs(hash(query.context)) % (2**31))
+    seed = query.seed if query.seed is not None else stable_seed(query.context)
+    rng = np.random.default_rng(seed)
 
     if query.investor_type == InvestorType.PASSIVE_INDEX:
         # Equal-weight (rational passive)

--- a/tests/test_retail_ai.py
+++ b/tests/test_retail_ai.py
@@ -1,0 +1,110 @@
+"""
+Regression tests for retail AI query -> allocation determinism.
+
+Guards #6: stub_llm_response seeded its RNG from builtin hash(), which Python
+randomizes per process (PEP 456), so mu_retail was irreproducible across runs.
+The determinism test therefore runs in subprocesses -- an in-process test would
+have passed even with the bug.
+"""
+
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+from agents.retail_ai import (
+    InvestorType,
+    RetailQuery,
+    aggregate_retail_strategy,
+    stable_seed,
+    stub_llm_response,
+)
+
+TICKERS = ["AAPL", "MSFT", "NVDA", "TSLA"]
+
+SNIPPET = """
+from agents.retail_ai import RetailQuery, InvestorType, stub_llm_response
+T = ['AAPL', 'MSFT', 'NVDA', 'TSLA']
+q = RetailQuery(InvestorType.{arch}, T, 'Should I buy the dip?', 0.5)
+print(','.join(f'{{x:.10f}}' for x in stub_llm_response(q, T)))
+"""
+
+
+def _run(arch: str) -> str:
+    r = subprocess.run(
+        [sys.executable, "-c", SNIPPET.format(arch=arch)],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert r.returncode == 0, r.stderr
+    return r.stdout.strip()
+
+
+class TestCrossProcessDeterminism:
+    @pytest.mark.parametrize("arch", ["DIY_QUANT", "MEME_TRADER", "PASSIVE_INDEX"])
+    def test_identical_across_processes(self, arch):
+        """The core guard for #6. DIY_QUANT draws from the RNG, so it is the
+        archetype that actually exercised the randomized-hash seed."""
+        assert len({_run(arch) for _ in range(3)}) == 1
+
+
+class TestStableSeed:
+    def test_deterministic(self):
+        assert stable_seed("buy the dip") == stable_seed("buy the dip")
+
+    def test_salt_changes_output(self):
+        assert stable_seed("x", salt=0) != stable_seed("x", salt=1)
+
+    def test_fits_in_uint32(self):
+        assert 0 <= stable_seed("anything") < 2**32
+
+
+class TestSeedOverride:
+    def test_explicit_seed_wins(self):
+        a, b = (
+            stub_llm_response(
+                RetailQuery(InvestorType.DIY_QUANT, TICKERS, ctx, 0.5, seed=99),
+                TICKERS,
+            )
+            for ctx in ("question one", "a totally different question")
+        )
+        np.testing.assert_allclose(a, b)
+
+    def test_different_seeds_differ(self):
+        a, b = (
+            stub_llm_response(
+                RetailQuery(InvestorType.DIY_QUANT, TICKERS, "same", 0.5, seed=s),
+                TICKERS,
+            )
+            for s in (1, 2)
+        )
+        assert not np.allclose(a, b)
+
+    def test_seed_defaults_to_none(self):
+        assert RetailQuery(InvestorType.PASSIVE_INDEX, TICKERS, "c", 0.5).seed is None
+
+
+class TestAllocationContract:
+    @pytest.mark.parametrize("arch", list(InvestorType))
+    def test_is_a_simplex_point(self, arch):
+        """Every archetype must return a valid allocation over the full universe."""
+        alloc = stub_llm_response(
+            RetailQuery(arch, ["AAPL"], "Should I buy the dip?", 0.5), TICKERS
+        )
+        assert alloc.shape == (len(TICKERS),)
+        assert (alloc >= 0).all()
+        np.testing.assert_allclose(alloc.sum(), 1.0, atol=1e-9)
+
+
+class TestMuRetailReproducible:
+    def test_same_queries_same_mu(self):
+        """The property that actually matters: mu_retail is the mean-field
+        quantity behind Component 4c, so it must be reproducible."""
+        qs = [
+            RetailQuery(t, TICKERS, "Should I buy the dip?", 0.5)
+            for t in InvestorType
+        ]
+        np.testing.assert_allclose(
+            aggregate_retail_strategy(qs, TICKERS),
+            aggregate_retail_strategy(qs, TICKERS),
+        )


### PR DESCRIPTION
Fixes #6.

`stub_llm_response` seeded its RNG from builtin `hash()` of `query.context`. Python randomizes string hashing per process (PEP 456), so identical queries produced different allocations on every interpreter launch. This propagates through `aggregate_retail_strategy` to **μ_retail** — the mean-field quantity behind the Component 4c homogenization thesis — leaving it irreproducible run to run.

Only `DIY_QUANT` and `MEME_TRADER`'s fallback were affected; the other three archetypes never draw from `rng`, which is why the demos look stable at a glance.

## Changes

**`stable_seed(text, salt=0)`** — a 32-bit seed from a SHA-256 digest, stable across processes, machines, and Python versions. `hashlib` is stdlib, so no new dependency.

**`RetailQuery.seed: int | None = None`** — optional explicit seed, so a corpus can be replayed exactly. Defaults to `None` and falls back to `stable_seed(context)`, preserving every existing call site and the current "same question → same answer" behavior.

I put the seed on `RetailQuery` rather than on `stub_llm_response` because a query represents one investor asking one question at one moment — the seed belongs to that event and should travel with the record through `simulate_retail_query_distribution` into any downstream consumer. Happy to move it if you'd prefer the argument form.

**`tests/test_retail_ai.py`** — 15 tests. The determinism checks run in **subprocesses**, which matters: an in-process test would pass even with the bug, since hash randomization is fixed within a single interpreter. Also covers `stable_seed` properties, seed-override precedence, the allocation-simplex contract for all five archetypes, and μ_retail reproducibility through `aggregate_retail_strategy`.

## Verification

Before — same input, three processes:
```
[0.2905 0.2595 0.2249 0.2251]
[0.2167 0.2658 0.2333 0.2842]
[0.2045 0.3    0.2482 0.2474]
```

After:
```
[0.2052 0.2938 0.2448 0.2562]
[0.2052 0.2938 0.2448 0.2562]
[0.2052 0.2938 0.2448 0.2562]
```

Replaying the old seeding line in three subprocesses yields 3 distinct outputs, so the new test genuinely covers the regression rather than only failing on the missing import.

`pytest tests/ -q` → 65 passed on Python 3.13 / macOS arm64.

## Note on E5

This is groundwork for E5 as much as a bug fix. Measuring a live model's response dispersion needs a stub baseline whose own variance is zero — otherwise sampling temperature and stub noise are indistinguishable. The `salt` parameter is there so repeated draws can be requested deliberately when that's the intent.

Still curious about the question from #6: should repeated identical queries model a deterministic assistant (current behavior) or vary to reflect sampling temperature? That choice shapes how E5 defines the response kernel R̂(q).