### PR TITLE
feat(e5): response-kernel statistics for the LLM query atlas

### DIFF
--- a/e5/metrics.py
+++ b/e5/metrics.py
@@ -1,0 +1,183 @@
+"""
+E5 response-kernel statistics.
+
+Given allocations R[i, j, :] — model i, repeat j, a point on the allocation
+simplex over n assets — summarize the response kernel R̂(q).
+
+Motivation (README Component 4c):
+
+    μ_retail = (1 − h) · μ_idio + h · c_t
+
+As AI adoption rises, retail allocations collapse onto a platform consensus
+c_t. E5 measures c_t and h empirically instead of assuming them.
+
+Why three statistics rather than one
+------------------------------------
+Single-number summaries conflate distinct situations that carry very
+different systemic risk. Concretely, on 3 models × 8 repeats × 4 assets:
+
+  case                          spread   effect   concentration
+  unanimous, all-in one name    0.0006    0.000       0.905
+  unanimous, index fund         0.0005    0.000       0.000
+  all models differ             0.5854    0.913       0.094
+
+The first two rows are indistinguishable on agreement alone — mean pairwise
+cosine scores both 1.000 — yet unanimous "buy NVDA" is a crowding event and
+unanimous "hold an index fund" is not. Only `concentration` separates them.
+
+Conversely, normalized entropy of the mean allocation rates total
+disagreement (0.613) *above* partial agreement (0.355), because averaging
+disjoint concentrated bets yields a spread-out mean indistinguishable from
+genuinely diversified advice.
+
+A note on naming: `model_effect` measures model-specific structure, which is
+the opposite of herding — it is high when platforms hold competing house
+views. The quantity that maps to h is low `spread` together with high
+`concentration`. See crowding_index().
+
+See issue #8 for the full derivation and the estimators that were rejected.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+__all__ = [
+    "consensus",
+    "spread",
+    "concentration",
+    "model_effect",
+    "crowding_index",
+    "drift",
+]
+
+
+def _as_panel(R: ArrayLike) -> NDArray[np.float64]:
+    """Validate and coerce to (n_models, n_repeats, n_assets)."""
+    A = np.asarray(R, dtype=float)
+    if A.ndim != 3:
+        raise ValueError(f"expected (n_models, n_repeats, n_assets), got shape {A.shape}")
+    if A.size == 0:
+        raise ValueError("empty allocation panel")
+    if not np.isfinite(A).all():
+        raise ValueError("allocations contain NaN or inf")
+    if (A < -1e-9).any():
+        raise ValueError("allocations contain negative weights")
+    sums = A.sum(axis=-1)
+    if not np.allclose(sums, 1.0, atol=1e-6):
+        raise ValueError(f"allocations must sum to 1 (got {sums.min():.4f}–{sums.max():.4f})")
+    return A
+
+
+def consensus(R: ArrayLike) -> NDArray[np.float64]:
+    """The empirical c_t: mean allocation over all models and repeats."""
+    A = _as_panel(R)
+    return A.reshape(-1, A.shape[-1]).mean(axis=0)
+
+
+def spread(R: ArrayLike) -> float:
+    """
+    Mean squared distance from the consensus — the disagreement level.
+
+    0 means every response is identical. The maximum on the simplex is 2
+    (two disjoint vertices), but that bound is loose in practice; interpret
+    `spread` comparatively across queries rather than on an absolute scale.
+    """
+    A = _as_panel(R)
+    flat = A.reshape(-1, A.shape[-1])
+    return float(((flat - flat.mean(axis=0)) ** 2).sum(axis=1).mean())
+
+
+def concentration(R: ArrayLike) -> float:
+    """
+    Normalized HHI of the consensus: 0 = equal-weight, 1 = all-in one asset.
+
+        (Σ cᵢ² − 1/n) / (1 − 1/n)
+
+    This is what distinguishes unanimous concentrated advice (a crowding
+    event) from unanimous diversified advice (harmless).
+    """
+    c = consensus(R)
+    n = len(c)
+    if n == 1:
+        return 1.0
+    return float((np.square(c).sum() - 1.0 / n) / (1.0 - 1.0 / n))
+
+
+def model_effect(
+    R: ArrayLike,
+    n_permutations: int = 1000,
+    rng: np.random.Generator | None = None,
+) -> tuple[float, float]:
+    """
+    Permutation test for model-specific structure.
+
+    Returns (p_value, effect_size).
+
+    The test statistic is the spread of per-model mean allocations around the
+    grand mean. The null reassigns responses to models at random, destroying
+    model-specific structure while preserving the marginal distribution of
+    responses.
+
+        p_value     P(null statistic >= observed), add-one corrected so it is
+                    never exactly 0. Small p means models differ systematically.
+        effect_size 1 - null_mean/observed, clipped at 0. Reports magnitude,
+                    but is NOT interpretable on its own: under H0 the ratio
+                    fluctuates around 1, so the clip makes the raw effect
+                    bimodal (either exactly 0 or a large spurious value, roughly
+                    coin-flip). Use p_value for the decision; effect_size only
+                    to describe how large a detected difference is.
+
+        p high -> models are interchangeable draws (one shared consensus)
+        p low  -> each model has a distinct house view
+
+    Note the statistic must be computed per model and then compared across
+    models; a null that permutes labels a pooled statistic never reads is
+    mathematically identical to the observation (see #8).
+    """
+    A = _as_panel(R)
+    if A.shape[0] < 2:
+        raise ValueError("model_effect needs at least 2 models")
+    rng = rng or np.random.default_rng()
+
+    def between(P: NDArray[np.float64]) -> float:
+        grand = P.reshape(-1, P.shape[-1]).mean(axis=0)
+        return float(((P.mean(axis=1) - grand) ** 2).sum(axis=1).mean())
+
+    observed = between(A)
+    flat = A.reshape(-1, A.shape[-1])
+    draws = np.array([
+        between(flat[rng.permutation(len(flat))].reshape(A.shape))
+        for _ in range(n_permutations)
+    ])
+    p_value = float((1 + (draws >= observed).sum()) / (n_permutations + 1))
+    effect = 0.0 if observed < 1e-12 else float(max(0.0, 1.0 - draws.mean() / observed))
+    return p_value, effect
+
+
+def crowding_index(R: ArrayLike) -> float:
+    """
+    The systemic-risk-relevant summary: consensus tightness × concentration.
+
+        (1 − min(spread, 1)) · concentration
+
+    High only when models agree AND the thing agreed on is concentrated —
+    the configuration under which μ_retail deforms the mean field.
+    """
+    return float((1.0 - min(spread(R), 1.0)) * concentration(R))
+
+
+def drift(c_prev: ArrayLike, c_next: ArrayLike) -> float:
+    """
+    L2 distance between consensus vectors on consecutive dates.
+
+    Measured on a fixed prompt set, this is E5's day-to-day drift: how much
+    the advice everyone receives moves, independent of how tightly models
+    agree on any given day.
+    """
+    a = np.asarray(c_prev, dtype=float)
+    b = np.asarray(c_next, dtype=float)
+    if a.shape != b.shape:
+        raise ValueError(f"shape mismatch: {a.shape} vs {b.shape}")
+    return float(np.linalg.norm(a - b))

--- a/tests/test_e5_metrics.py
+++ b/tests/test_e5_metrics.py
@@ -1,0 +1,160 @@
+"""
+Tests for E5 response-kernel statistics.
+
+These encode the counterexamples from #8. Several assert *discrimination*
+between cases rather than exact values: the point is that unanimous
+concentrated advice and unanimous diversified advice must not receive the
+same score, which is precisely where cosine similarity and entropy fail.
+"""
+
+import numpy as np
+import pytest
+
+from e5.metrics import (
+    concentration,
+    consensus,
+    crowding_index,
+    drift,
+    model_effect,
+    spread,
+)
+
+N = 4
+ALL_IN = [1.0, 0.0, 0.0, 0.0]
+OTHER = [0.0, 1.0, 0.0, 0.0]
+THIRD = [0.0, 0.0, 1.0, 0.0]
+UNIFORM = [0.25] * 4
+
+
+def panel(bases, sigma=0.02, repeats=8, seed=0):
+    """Build (n_models, repeats, N) with each model noisy around its base."""
+    rng = np.random.default_rng(seed)
+    out = []
+    for b in bases:
+        x = np.abs(np.array(b, float) + rng.normal(0, sigma, (repeats, N)))
+        out.append(x / x.sum(1, keepdims=True))
+    return np.stack(out)
+
+
+class TestValidation:
+    def test_rejects_wrong_ndim(self):
+        with pytest.raises(ValueError, match="n_models"):
+            spread(np.ones((3, N)) / N)
+
+    def test_rejects_unnormalized(self):
+        with pytest.raises(ValueError, match="sum to 1"):
+            spread(np.ones((2, 2, N)))
+
+    def test_rejects_negative(self):
+        bad = np.tile([1.5, -0.5, 0.0, 0.0], (2, 2, 1))
+        with pytest.raises(ValueError, match="negative"):
+            spread(bad)
+
+    def test_rejects_nan(self):
+        bad = panel([ALL_IN, OTHER]).copy()
+        bad[0, 0, 0] = np.nan
+        with pytest.raises(ValueError, match="NaN"):
+            spread(bad)
+
+
+class TestConsensus:
+    def test_is_a_simplex_point(self):
+        c = consensus(panel([ALL_IN, OTHER, THIRD]))
+        assert c.shape == (N,)
+        assert (c >= 0).all()
+        np.testing.assert_allclose(c.sum(), 1.0)
+
+    def test_recovers_the_common_vector(self):
+        np.testing.assert_allclose(
+            consensus(panel([ALL_IN] * 3, sigma=0.0)), ALL_IN, atol=1e-9
+        )
+
+
+class TestSpread:
+    def test_zero_when_identical(self):
+        assert spread(panel([ALL_IN] * 3, sigma=0.0)) == pytest.approx(0.0, abs=1e-12)
+
+    def test_increases_with_disagreement(self):
+        assert spread(panel([ALL_IN] * 3)) < spread(panel([ALL_IN, OTHER, THIRD]))
+
+    def test_increases_with_noise(self):
+        assert spread(panel([ALL_IN] * 3, sigma=0.02)) < spread(
+            panel([ALL_IN] * 3, sigma=0.40)
+        )
+
+
+class TestConcentration:
+    def test_zero_for_equal_weight(self):
+        assert concentration(panel([UNIFORM] * 3, sigma=0.0)) == pytest.approx(0.0, abs=1e-9)
+
+    def test_one_for_all_in(self):
+        assert concentration(panel([ALL_IN] * 3, sigma=0.0)) == pytest.approx(1.0, abs=1e-9)
+
+    def test_disjoint_bets_average_out(self):
+        """Three models each all-in on a different name yields a diffuse
+        consensus — the case where entropy of the mean is misleading."""
+        assert concentration(panel([ALL_IN, OTHER, THIRD], sigma=0.0)) < 0.2
+
+
+class TestModelEffect:
+    def test_calibrated_under_null(self):
+        """Under H0 the p-value must be roughly uniform, not concentrated near
+        0. A raw effect size fails this: the max(0, .) clip makes it bimodal."""
+        ps = [
+            model_effect(panel([ALL_IN] * 3, seed=s), rng=np.random.default_rng(0))[0]
+            for s in range(20)
+        ]
+        assert sum(p < 0.05 for p in ps) <= 4, f"too many false positives: {ps}"
+        assert max(ps) > 0.5, "p-values never reach the upper range"
+
+    def test_detects_house_views(self):
+        p, effect = model_effect(panel([ALL_IN, OTHER, THIRD]), rng=np.random.default_rng(0))
+        assert p <= 0.01
+        assert effect > 0.8
+
+    def test_noise_alone_is_not_structure(self):
+        """High noise but no house views must not register as model-specific."""
+        p, _ = model_effect(
+            panel([ALL_IN] * 3, sigma=0.40, repeats=64), rng=np.random.default_rng(0)
+        )
+        assert p > 0.05
+
+    def test_requires_two_models(self):
+        with pytest.raises(ValueError, match="at least 2"):
+            model_effect(panel([ALL_IN]))
+
+    def test_reproducible_given_seed(self):
+        R = panel([ALL_IN, OTHER, THIRD])
+        a = model_effect(R, n_permutations=200, rng=np.random.default_rng(3))
+        b = model_effect(R, n_permutations=200, rng=np.random.default_rng(3))
+        assert a == b
+
+
+class TestCrowdingIndex:
+    def test_separates_the_two_unanimous_cases(self):
+        """THE counterexample from #8: cosine similarity scores both of these
+        1.000, but only one is a crowding event."""
+        assert crowding_index(panel([ALL_IN] * 3)) > 0.8
+        assert crowding_index(panel([UNIFORM] * 3)) < 0.1
+
+    def test_low_under_disagreement(self):
+        assert crowding_index(panel([ALL_IN, OTHER, THIRD])) < 0.2
+
+    def test_bounded(self):
+        for bases in ([ALL_IN] * 3, [UNIFORM] * 3, [ALL_IN, OTHER, THIRD]):
+            assert 0.0 <= crowding_index(panel(bases)) <= 1.0
+
+
+class TestDrift:
+    def test_zero_for_identical(self):
+        assert drift(UNIFORM, UNIFORM) == pytest.approx(0.0)
+
+    def test_positive_when_consensus_moves(self):
+        assert drift(ALL_IN, OTHER) > 1.0
+
+    def test_symmetric(self):
+        assert drift(ALL_IN, UNIFORM) == pytest.approx(drift(UNIFORM, ALL_IN))
+
+    def test_shape_mismatch_raises(self):
+        with pytest.raises(ValueError, match="shape mismatch"):
+            drift([0.5, 0.5], [0.3, 0.3, 0.4])


### PR DESCRIPTION
Implements the metrics proposed in #8. This is the measurement layer for E5 — no harness, no API calls, no new dependencies beyond numpy.

## Why not a single agreement number

`DATA_REQUIREMENTS.md` §1.6 asks for "concentration, day-to-day drift, and cross-model herding coefficient ĥ" without specifying estimators. I tested the obvious candidates against synthetic cases with known answers first; each fails in a way that matters.

**Mean pairwise cosine** scores these identically at 1.000:

| case | cosine | concentration |
|---|---|---|
| unanimous, all-in one name | 1.000 | 0.905 |
| unanimous, index fund | 1.000 | 0.000 |

Unanimous "buy NVDA" is a crowding event; unanimous "hold an index fund" is not. Cosine is blind to what is agreed on.

**Normalized entropy of the mean** rates total disagreement (0.613) above partial agreement (0.355), because three disjoint concentrated bets average into a diffuse consensus indistinguishable from genuinely diversified advice.

**Between-model variance share** is sign-inverted — 0.233 for identical models, 0.999 for completely different ones. It measures systematic difference, not commonality.

## What's here

`consensus` (the empirical c_t), `spread`, `concentration` (normalized HHI), `model_effect`, `crowding_index`, `drift`.

`crowding_index = (1 − spread) · concentration` is the quantity that maps to h in μ_retail = (1−h)μ_idio + h·c_t — high only when models agree *and* the thing agreed on is concentrated:

| case | spread | concentration | crowding |
|---|---|---|---|
| unanimous, all-in | 0.0006 | 0.889 | 0.889 |
| unanimous, index | 0.0009 | 0.000 | 0.000 |
| all models differ | 0.5970 | 0.096 | 0.039 |

## The part worth reviewing closely

`model_effect` returns `(p_value, effect_size)` rather than a scalar, and the reason is a bug I hit and had to fix.

My first version returned `1 − null_mean/observed`. Under H₀ that ratio fluctuates around 1, so `max(0, ·)` makes the statistic **bimodal** — across 8 seeds with identical models it gave `[0.636, 0.0, 0.0, 0.23, 0.589, 0.0, 0.0, 0.0]`. Roughly a coin flip between exactly zero and a large spurious value. It also doesn't converge: 8→32→128→512 repeats gave 0.636, 0.000, 0.696, 0.047.

An earlier attempt was worse — I permuted model labels on a *pooled* statistic that never reads them, so observed and null were mathematically identical (0.0000 difference to four decimals on every case). Recorded in the docstring so it isn't repeated.

The fix is a proper permutation test. The p-value is uniform under H₀ by construction, and the test asserts calibration across 20 seeds rather than trusting one realization. On real house views it hits the B=1000 floor (p=0.001) on every seed tested.

Naming note: `model_effect` measures model-*specific* structure, which is the opposite of herding — it's high when platforms hold competing house views. It's a diagnostic for whether the landscape is homogeneous or fragmented, not ĥ itself.

## Tests

24 tests, `pytest tests/ -q` → 74 passed on Python 3.13 / macOS arm64. Several assert discrimination between the counterexample cases rather than exact values, so the module can't silently regress to an estimator that conflates them.

## Open questions (also in #8)

1. Does the two-statistic decomposition match your intent, or did you want a single ĥ?
2. Per-query, per-archetype, or pooled estimation?
3. Plan for the harness is stub-mode + recorded-fixture replay so it stays fully testable offline per the zero-key policy, with a thin provider interface for live calls — you'd run it on your own keys rather than me shipping a one-off dataset. Does that fit?

Depends on #7 in spirit but not in code: measuring response dispersion needs a stub baseline with zero variance of its own, otherwise sampling temperature and stub noise are indistinguishable.