### PR TITLE
feat(e5): measurement layer for the LLM query atlas - corpus + response-kernel statistics

### DIFF
--- a/agents/retail_ai.py
+++ b/agents/retail_ai.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import os
 import numpy as np
 from dataclasses import dataclass
+import hashlib
 from enum import Enum
 from typing import Optional
 
@@ -42,6 +43,18 @@ class InvestorType(Enum):
     MEME_TRADER     = "meme_trader"      # social-media driven, asks about short interest
 
 
+def stable_seed(text: str, salt: int = 0) -> int:
+    """
+    Process-stable 32-bit seed derived from a string.
+
+    Python randomizes builtin hash() of str per process (PEP 456), so seeding
+    an RNG from it makes results irreproducible across interpreter launches.
+    SHA-256 is stable across processes, machines, and Python versions.
+    """
+    digest = hashlib.sha256(f"{salt}:{text}".encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], "big")
+
+
 @dataclass
 class RetailQuery:
     """A single retail investor's AI query at time t."""
@@ -49,6 +62,7 @@ class RetailQuery:
     tickers: list[str]
     context: str      # natural language context (earnings, news, etc.)
     risk_tolerance: float  # 0=very conservative, 1=very aggressive
+    seed: int | None = None  # explicit seed; falls back to stable_seed(context)
 
 
 def simulate_retail_query_distribution(
@@ -145,7 +159,8 @@ def stub_llm_response(
     ticker_to_idx = {t: i for i, t in enumerate(tickers)}
     alloc = np.zeros(n)
 
-    rng = np.random.default_rng(abs(hash(query.context)) % (2**31))
+    seed = query.seed if query.seed is not None else stable_seed(query.context)
+    rng = np.random.default_rng(seed)
 
     if query.investor_type == InvestorType.PASSIVE_INDEX:
         # Equal-weight (rational passive)

--- a/e5/corpus.py
+++ b/e5/corpus.py
@@ -1,0 +1,181 @@
+"""
+E5 prompt corpus: the stratified query grid sent to every model under audit.
+
+DATA_REQUIREMENTS.md §1.6 specifies the corpus as
+
+    5 archetypes × tickers × market conditions × dates
+
+This module enumerates that cross-product deterministically. It is
+deliberately *not* a wrapper around
+`agents.retail_ai.simulate_retail_query_distribution`, which answers a
+different question:
+
+    simulate_retail_query_distribution  "what is the retail population
+                                         asking today?" — a stochastic draw
+                                         of n_investors × adoption_rate
+
+    build_corpus                        "here is prompt #147; send it to
+                                         every model, on every date, every
+                                         run" — a fixed, replayable grid
+
+Both use the same five archetypes and the same stress-shift intuition. The
+audit needs the grid because R̂(q) is a *conditional* kernel: comparing
+models requires holding q fixed, and measuring drift requires holding q
+fixed across dates.
+
+`RetailQuery` carries no date field, so this module pairs each query with
+its own record type. Drift is defined as ‖c̄_t − c̄_{t−1}‖ on a fixed prompt
+set, which is uncomputable without one.
+"""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass, field
+from datetime import date
+
+from agents.retail_ai import InvestorType, RetailQuery, stable_seed
+
+__all__ = ["CorpusItem", "MarketCondition", "PROMPT_TEMPLATES", "build_corpus"]
+
+
+@dataclass(frozen=True)
+class MarketCondition:
+    """A named market regime. `stress` matches the [0,1] scale used by
+    agents.retail_ai (0 = calm, 1 = crisis)."""
+    name: str
+    stress: float
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.stress <= 1.0:
+            raise ValueError(f"stress must be in [0,1], got {self.stress}")
+
+
+CALM = MarketCondition("calm", 0.0)
+ELEVATED = MarketCondition("elevated", 0.5)
+CRISIS = MarketCondition("crisis", 1.0)
+
+DEFAULT_CONDITIONS: tuple[MarketCondition, ...] = (CALM, ELEVATED, CRISIS)
+
+# One template per archetype per condition. The archetype fixes what the
+# investor wants; the condition fixes the framing they bring to it. Kept as
+# data rather than f-string logic so the exact prompt text is reviewable and
+# citable in the published dataset.
+PROMPT_TEMPLATES: dict[InvestorType, dict[str, str]] = {
+    InvestorType.PASSIVE_INDEX: {
+        "calm": "I hold {tickers}. Should I rebalance? Give me target weights.",
+        "elevated": "Markets have been choppy. I hold {tickers}. Should I rebalance? Give me target weights.",
+        "crisis": "Markets are selling off hard. I hold {tickers}. Should I rebalance? Give me target weights.",
+    },
+    InvestorType.ACTIVE_FOLLOWER: {
+        "calm": "What's hot right now among {tickers}? How should I allocate?",
+        "elevated": "With volatility picking up, what's hot among {tickers}? How should I allocate?",
+        "crisis": "In this crash, what's still working among {tickers}? How should I allocate?",
+    },
+    InvestorType.NEWS_REACTOR: {
+        "calm": "There's news on {tickers}. What does it mean for my portfolio? Give me an allocation.",
+        "elevated": "There's news on {tickers} and markets are jumpy. What does it mean for my portfolio? Give me an allocation.",
+        "crisis": "There's news on {tickers} in the middle of a selloff. What does it mean for my portfolio? Give me an allocation.",
+    },
+    InvestorType.DIY_QUANT: {
+        "calm": "Backtest a momentum tilt across {tickers} and give me the resulting allocation.",
+        "elevated": "Backtest a momentum tilt across {tickers} in a higher-vol regime and give me the resulting allocation.",
+        "crisis": "Backtest a momentum tilt across {tickers} through a drawdown and give me the resulting allocation.",
+    },
+    InvestorType.MEME_TRADER: {
+        "calm": "What's the short interest on {tickers}? Where should I put my money?",
+        "elevated": "What's the short interest on {tickers} with vol rising? Where should I put my money?",
+        "crisis": "What's the short interest on {tickers} during this crash? Where should I put my money?",
+    },
+}
+
+# Risk tolerance is held fixed per archetype rather than sampled: the audit
+# varies one thing at a time, and a random risk score would confound
+# archetype effects with risk effects.
+RISK_TOLERANCE: dict[InvestorType, float] = {
+    InvestorType.PASSIVE_INDEX: 0.2,
+    InvestorType.ACTIVE_FOLLOWER: 0.6,
+    InvestorType.NEWS_REACTOR: 0.5,
+    InvestorType.DIY_QUANT: 0.6,
+    InvestorType.MEME_TRADER: 0.9,
+}
+
+
+@dataclass(frozen=True)
+class CorpusItem:
+    """One cell of the audit grid. `query_id` is stable across runs, so a
+    response recorded today can be matched to the same prompt next month."""
+    query_id: str
+    archetype: InvestorType
+    tickers: tuple[str, ...]
+    condition: MarketCondition
+    as_of: date
+    prompt: str
+    query: RetailQuery = field(compare=False, repr=False)
+
+
+def _ticker_groups(tickers: list[str], group_size: int) -> list[tuple[str, ...]]:
+    """Fixed, non-overlapping-order ticker subsets. Combinations rather than
+    random draws so the grid is enumerable and identical every run."""
+    if group_size < 1:
+        raise ValueError("group_size must be >= 1")
+    if group_size > len(tickers):
+        raise ValueError(f"group_size {group_size} exceeds universe of {len(tickers)}")
+    return list(itertools.combinations(tickers, group_size))
+
+
+def build_corpus(
+    tickers: list[str],
+    dates: list[date],
+    conditions: tuple[MarketCondition, ...] = DEFAULT_CONDITIONS,
+    archetypes: tuple[InvestorType, ...] | None = None,
+    group_size: int = 2,
+    max_ticker_groups: int | None = None,
+) -> list[CorpusItem]:
+    """
+    Enumerate the audit grid.
+
+    Size is |archetypes| × |ticker groups| × |conditions| × |dates|, which
+    grows fast: 5 × C(10,2) × 3 × 5 = 3,375. `max_ticker_groups` truncates
+    deterministically (first-N of the sorted combinations) for pilot runs.
+
+    Every item gets a `query_id` derived from its coordinates via
+    `stable_seed`, so the same cell has the same id across processes and
+    machines — the property that makes recorded fixtures replayable.
+    """
+    if not tickers:
+        raise ValueError("empty ticker universe")
+    if not dates:
+        raise ValueError("no dates given; drift needs at least 2")
+    if len(set(tickers)) != len(tickers):
+        raise ValueError("duplicate tickers")
+
+    archetypes = archetypes or tuple(InvestorType)
+    groups = _ticker_groups(sorted(tickers), group_size)
+    if max_ticker_groups is not None:
+        groups = groups[:max_ticker_groups]
+
+    items: list[CorpusItem] = []
+    for arch, group, cond, day in itertools.product(archetypes, groups, conditions, sorted(dates)):
+        template = PROMPT_TEMPLATES[arch][cond.name]
+        prompt = template.format(tickers=", ".join(group))
+        coord = f"{arch.value}|{'-'.join(group)}|{cond.name}|{day.isoformat()}"
+        qid = f"q{stable_seed(coord):08x}"
+        items.append(
+            CorpusItem(
+                query_id=qid,
+                archetype=arch,
+                tickers=group,
+                condition=cond,
+                as_of=day,
+                prompt=prompt,
+                query=RetailQuery(
+                    investor_type=arch,
+                    tickers=list(group),
+                    context=prompt,
+                    risk_tolerance=RISK_TOLERANCE[arch],
+                    seed=stable_seed(coord),
+                ),
+            )
+        )
+    return items

--- a/e5/metrics.py
+++ b/e5/metrics.py
@@ -1,0 +1,183 @@
+"""
+E5 response-kernel statistics.
+
+Given allocations R[i, j, :] — model i, repeat j, a point on the allocation
+simplex over n assets — summarize the response kernel R̂(q).
+
+Motivation (README Component 4c):
+
+    μ_retail = (1 − h) · μ_idio + h · c_t
+
+As AI adoption rises, retail allocations collapse onto a platform consensus
+c_t. E5 measures c_t and h empirically instead of assuming them.
+
+Why three statistics rather than one
+------------------------------------
+Single-number summaries conflate distinct situations that carry very
+different systemic risk. Concretely, on 3 models × 8 repeats × 4 assets:
+
+  case                          spread   effect   concentration
+  unanimous, all-in one name    0.0006    0.000       0.905
+  unanimous, index fund         0.0005    0.000       0.000
+  all models differ             0.5854    0.913       0.094
+
+The first two rows are indistinguishable on agreement alone — mean pairwise
+cosine scores both 1.000 — yet unanimous "buy NVDA" is a crowding event and
+unanimous "hold an index fund" is not. Only `concentration` separates them.
+
+Conversely, normalized entropy of the mean allocation rates total
+disagreement (0.613) *above* partial agreement (0.355), because averaging
+disjoint concentrated bets yields a spread-out mean indistinguishable from
+genuinely diversified advice.
+
+A note on naming: `model_effect` measures model-specific structure, which is
+the opposite of herding — it is high when platforms hold competing house
+views. The quantity that maps to h is low `spread` together with high
+`concentration`. See crowding_index().
+
+See issue #8 for the full derivation and the estimators that were rejected.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+__all__ = [
+    "consensus",
+    "spread",
+    "concentration",
+    "model_effect",
+    "crowding_index",
+    "drift",
+]
+
+
+def _as_panel(R: ArrayLike) -> NDArray[np.float64]:
+    """Validate and coerce to (n_models, n_repeats, n_assets)."""
+    A = np.asarray(R, dtype=float)
+    if A.ndim != 3:
+        raise ValueError(f"expected (n_models, n_repeats, n_assets), got shape {A.shape}")
+    if A.size == 0:
+        raise ValueError("empty allocation panel")
+    if not np.isfinite(A).all():
+        raise ValueError("allocations contain NaN or inf")
+    if (A < -1e-9).any():
+        raise ValueError("allocations contain negative weights")
+    sums = A.sum(axis=-1)
+    if not np.allclose(sums, 1.0, atol=1e-6):
+        raise ValueError(f"allocations must sum to 1 (got {sums.min():.4f}–{sums.max():.4f})")
+    return A
+
+
+def consensus(R: ArrayLike) -> NDArray[np.float64]:
+    """The empirical c_t: mean allocation over all models and repeats."""
+    A = _as_panel(R)
+    return A.reshape(-1, A.shape[-1]).mean(axis=0)
+
+
+def spread(R: ArrayLike) -> float:
+    """
+    Mean squared distance from the consensus — the disagreement level.
+
+    0 means every response is identical. The maximum on the simplex is 2
+    (two disjoint vertices), but that bound is loose in practice; interpret
+    `spread` comparatively across queries rather than on an absolute scale.
+    """
+    A = _as_panel(R)
+    flat = A.reshape(-1, A.shape[-1])
+    return float(((flat - flat.mean(axis=0)) ** 2).sum(axis=1).mean())
+
+
+def concentration(R: ArrayLike) -> float:
+    """
+    Normalized HHI of the consensus: 0 = equal-weight, 1 = all-in one asset.
+
+        (Σ cᵢ² − 1/n) / (1 − 1/n)
+
+    This is what distinguishes unanimous concentrated advice (a crowding
+    event) from unanimous diversified advice (harmless).
+    """
+    c = consensus(R)
+    n = len(c)
+    if n == 1:
+        return 1.0
+    return float((np.square(c).sum() - 1.0 / n) / (1.0 - 1.0 / n))
+
+
+def model_effect(
+    R: ArrayLike,
+    n_permutations: int = 1000,
+    rng: np.random.Generator | None = None,
+) -> tuple[float, float]:
+    """
+    Permutation test for model-specific structure.
+
+    Returns (p_value, effect_size).
+
+    The test statistic is the spread of per-model mean allocations around the
+    grand mean. The null reassigns responses to models at random, destroying
+    model-specific structure while preserving the marginal distribution of
+    responses.
+
+        p_value     P(null statistic >= observed), add-one corrected so it is
+                    never exactly 0. Small p means models differ systematically.
+        effect_size 1 - null_mean/observed, clipped at 0. Reports magnitude,
+                    but is NOT interpretable on its own: under H0 the ratio
+                    fluctuates around 1, so the clip makes the raw effect
+                    bimodal (either exactly 0 or a large spurious value, roughly
+                    coin-flip). Use p_value for the decision; effect_size only
+                    to describe how large a detected difference is.
+
+        p high -> models are interchangeable draws (one shared consensus)
+        p low  -> each model has a distinct house view
+
+    Note the statistic must be computed per model and then compared across
+    models; a null that permutes labels a pooled statistic never reads is
+    mathematically identical to the observation (see #8).
+    """
+    A = _as_panel(R)
+    if A.shape[0] < 2:
+        raise ValueError("model_effect needs at least 2 models")
+    rng = rng or np.random.default_rng()
+
+    def between(P: NDArray[np.float64]) -> float:
+        grand = P.reshape(-1, P.shape[-1]).mean(axis=0)
+        return float(((P.mean(axis=1) - grand) ** 2).sum(axis=1).mean())
+
+    observed = between(A)
+    flat = A.reshape(-1, A.shape[-1])
+    draws = np.array([
+        between(flat[rng.permutation(len(flat))].reshape(A.shape))
+        for _ in range(n_permutations)
+    ])
+    p_value = float((1 + (draws >= observed).sum()) / (n_permutations + 1))
+    effect = 0.0 if observed < 1e-12 else float(max(0.0, 1.0 - draws.mean() / observed))
+    return p_value, effect
+
+
+def crowding_index(R: ArrayLike) -> float:
+    """
+    The systemic-risk-relevant summary: consensus tightness × concentration.
+
+        (1 − min(spread, 1)) · concentration
+
+    High only when models agree AND the thing agreed on is concentrated —
+    the configuration under which μ_retail deforms the mean field.
+    """
+    return float((1.0 - min(spread(R), 1.0)) * concentration(R))
+
+
+def drift(c_prev: ArrayLike, c_next: ArrayLike) -> float:
+    """
+    L2 distance between consensus vectors on consecutive dates.
+
+    Measured on a fixed prompt set, this is E5's day-to-day drift: how much
+    the advice everyone receives moves, independent of how tightly models
+    agree on any given day.
+    """
+    a = np.asarray(c_prev, dtype=float)
+    b = np.asarray(c_next, dtype=float)
+    if a.shape != b.shape:
+        raise ValueError(f"shape mismatch: {a.shape} vs {b.shape}")
+    return float(np.linalg.norm(a - b))

--- a/tests/test_e5_corpus.py
+++ b/tests/test_e5_corpus.py
@@ -1,0 +1,140 @@
+"""
+Tests for the E5 audit grid.
+
+The properties that matter are the ones the harness depends on: the grid is
+enumerable, query_ids are stable across processes (so recorded responses can
+be matched to prompts on a later run), and the cross-product axes actually
+vary the prompt.
+"""
+
+import subprocess
+import sys
+from datetime import date
+
+import pytest
+
+from agents.retail_ai import InvestorType
+from e5.corpus import (
+    CALM,
+    CRISIS,
+    DEFAULT_CONDITIONS,
+    PROMPT_TEMPLATES,
+    MarketCondition,
+    build_corpus,
+)
+
+TICKERS = ["AAPL", "MSFT", "NVDA", "TSLA"]
+DATES = [date(2026, 8, 1), date(2026, 8, 2)]
+
+
+def corpus(**kw):
+    kw.setdefault("max_ticker_groups", 3)
+    return build_corpus(TICKERS, DATES, **kw)
+
+
+class TestGridShape:
+    def test_size_is_the_cross_product(self):
+        c = corpus()
+        assert len(c) == len(InvestorType) * 3 * len(DEFAULT_CONDITIONS) * len(DATES)
+
+    def test_every_axis_is_present(self):
+        c = corpus()
+        assert {i.archetype for i in c} == set(InvestorType)
+        assert {i.condition.name for i in c} == {x.name for x in DEFAULT_CONDITIONS}
+        assert {i.as_of for i in c} == set(DATES)
+
+    def test_group_size_controls_tickers_per_prompt(self):
+        assert all(len(i.tickers) == 3 for i in corpus(group_size=3))
+
+    def test_archetype_subset_is_honored(self):
+        c = corpus(archetypes=(InvestorType.MEME_TRADER,))
+        assert {i.archetype for i in c} == {InvestorType.MEME_TRADER}
+
+
+class TestQueryIds:
+    def test_unique_across_the_grid(self):
+        ids = [i.query_id for i in corpus()]
+        assert len(set(ids)) == len(ids)
+
+    def test_stable_across_processes(self):
+        """Same reason as #7: a per-process hash would make recorded fixtures
+        unmatchable on a later run."""
+        snippet = (
+            "from datetime import date;"
+            "from e5.corpus import build_corpus;"
+            "c=build_corpus(['AAPL','MSFT','NVDA','TSLA'],"
+            "[date(2026,8,1),date(2026,8,2)],max_ticker_groups=3);"
+            "print(','.join(i.query_id for i in c))"
+        )
+        outs = set()
+        for _ in range(3):
+            r = subprocess.run([sys.executable, "-c", snippet],
+                               capture_output=True, text=True, timeout=60)
+            assert r.returncode == 0, r.stderr
+            outs.add(r.stdout.strip())
+        assert len(outs) == 1
+
+    def test_id_changes_with_each_coordinate(self):
+        """A collision on any axis would silently merge two cells."""
+        base = corpus()[0]
+        others = corpus(archetypes=(InvestorType.MEME_TRADER,))
+        assert base.query_id not in {o.query_id for o in others}
+
+
+class TestPrompts:
+    def test_condition_changes_the_prompt(self):
+        c = corpus(archetypes=(InvestorType.PASSIVE_INDEX,))
+        by_cond = {i.condition.name: i.prompt for i in c if i.as_of == DATES[0]
+                   and i.tickers == ("AAPL", "MSFT")}
+        assert len(set(by_cond.values())) == len(DEFAULT_CONDITIONS)
+
+    def test_tickers_appear_in_prompt(self):
+        for i in corpus():
+            for t in i.tickers:
+                assert t in i.prompt
+
+    def test_every_archetype_condition_pair_has_a_template(self):
+        for arch in InvestorType:
+            for cond in DEFAULT_CONDITIONS:
+                assert cond.name in PROMPT_TEMPLATES[arch]
+
+    def test_query_context_matches_prompt(self):
+        """The RetailQuery handed to the stub must carry the same text sent
+        to a live model, or stub and live runs aren't comparable."""
+        assert all(i.query.context == i.prompt for i in corpus())
+
+
+class TestValidation:
+    def test_empty_tickers(self):
+        with pytest.raises(ValueError, match="empty ticker"):
+            build_corpus([], DATES)
+
+    def test_no_dates(self):
+        with pytest.raises(ValueError, match="no dates"):
+            build_corpus(TICKERS, [])
+
+    def test_duplicate_tickers(self):
+        with pytest.raises(ValueError, match="duplicate"):
+            build_corpus(["AAPL", "AAPL"], DATES)
+
+    def test_group_size_too_large(self):
+        with pytest.raises(ValueError, match="exceeds universe"):
+            build_corpus(TICKERS, DATES, group_size=99)
+
+    def test_stress_out_of_range(self):
+        with pytest.raises(ValueError, match=r"\[0,1\]"):
+            MarketCondition("bad", 1.5)
+
+
+class TestStubBaseline:
+    def test_stub_response_is_fixed_per_cell(self):
+        """The corpus seeds each query from its coordinates, so the stub is a
+        zero-variance baseline — otherwise stub noise and a live model's
+        sampling temperature are indistinguishable."""
+        import numpy as np
+        from agents.retail_ai import stub_llm_response
+
+        item = corpus()[0]
+        a = stub_llm_response(item.query, TICKERS)
+        b = stub_llm_response(item.query, TICKERS)
+        np.testing.assert_allclose(a, b)

--- a/tests/test_e5_metrics.py
+++ b/tests/test_e5_metrics.py
@@ -1,0 +1,160 @@
+"""
+Tests for E5 response-kernel statistics.
+
+These encode the counterexamples from #8. Several assert *discrimination*
+between cases rather than exact values: the point is that unanimous
+concentrated advice and unanimous diversified advice must not receive the
+same score, which is precisely where cosine similarity and entropy fail.
+"""
+
+import numpy as np
+import pytest
+
+from e5.metrics import (
+    concentration,
+    consensus,
+    crowding_index,
+    drift,
+    model_effect,
+    spread,
+)
+
+N = 4
+ALL_IN = [1.0, 0.0, 0.0, 0.0]
+OTHER = [0.0, 1.0, 0.0, 0.0]
+THIRD = [0.0, 0.0, 1.0, 0.0]
+UNIFORM = [0.25] * 4
+
+
+def panel(bases, sigma=0.02, repeats=8, seed=0):
+    """Build (n_models, repeats, N) with each model noisy around its base."""
+    rng = np.random.default_rng(seed)
+    out = []
+    for b in bases:
+        x = np.abs(np.array(b, float) + rng.normal(0, sigma, (repeats, N)))
+        out.append(x / x.sum(1, keepdims=True))
+    return np.stack(out)
+
+
+class TestValidation:
+    def test_rejects_wrong_ndim(self):
+        with pytest.raises(ValueError, match="n_models"):
+            spread(np.ones((3, N)) / N)
+
+    def test_rejects_unnormalized(self):
+        with pytest.raises(ValueError, match="sum to 1"):
+            spread(np.ones((2, 2, N)))
+
+    def test_rejects_negative(self):
+        bad = np.tile([1.5, -0.5, 0.0, 0.0], (2, 2, 1))
+        with pytest.raises(ValueError, match="negative"):
+            spread(bad)
+
+    def test_rejects_nan(self):
+        bad = panel([ALL_IN, OTHER]).copy()
+        bad[0, 0, 0] = np.nan
+        with pytest.raises(ValueError, match="NaN"):
+            spread(bad)
+
+
+class TestConsensus:
+    def test_is_a_simplex_point(self):
+        c = consensus(panel([ALL_IN, OTHER, THIRD]))
+        assert c.shape == (N,)
+        assert (c >= 0).all()
+        np.testing.assert_allclose(c.sum(), 1.0)
+
+    def test_recovers_the_common_vector(self):
+        np.testing.assert_allclose(
+            consensus(panel([ALL_IN] * 3, sigma=0.0)), ALL_IN, atol=1e-9
+        )
+
+
+class TestSpread:
+    def test_zero_when_identical(self):
+        assert spread(panel([ALL_IN] * 3, sigma=0.0)) == pytest.approx(0.0, abs=1e-12)
+
+    def test_increases_with_disagreement(self):
+        assert spread(panel([ALL_IN] * 3)) < spread(panel([ALL_IN, OTHER, THIRD]))
+
+    def test_increases_with_noise(self):
+        assert spread(panel([ALL_IN] * 3, sigma=0.02)) < spread(
+            panel([ALL_IN] * 3, sigma=0.40)
+        )
+
+
+class TestConcentration:
+    def test_zero_for_equal_weight(self):
+        assert concentration(panel([UNIFORM] * 3, sigma=0.0)) == pytest.approx(0.0, abs=1e-9)
+
+    def test_one_for_all_in(self):
+        assert concentration(panel([ALL_IN] * 3, sigma=0.0)) == pytest.approx(1.0, abs=1e-9)
+
+    def test_disjoint_bets_average_out(self):
+        """Three models each all-in on a different name yields a diffuse
+        consensus — the case where entropy of the mean is misleading."""
+        assert concentration(panel([ALL_IN, OTHER, THIRD], sigma=0.0)) < 0.2
+
+
+class TestModelEffect:
+    def test_calibrated_under_null(self):
+        """Under H0 the p-value must be roughly uniform, not concentrated near
+        0. A raw effect size fails this: the max(0, .) clip makes it bimodal."""
+        ps = [
+            model_effect(panel([ALL_IN] * 3, seed=s), rng=np.random.default_rng(0))[0]
+            for s in range(20)
+        ]
+        assert sum(p < 0.05 for p in ps) <= 4, f"too many false positives: {ps}"
+        assert max(ps) > 0.5, "p-values never reach the upper range"
+
+    def test_detects_house_views(self):
+        p, effect = model_effect(panel([ALL_IN, OTHER, THIRD]), rng=np.random.default_rng(0))
+        assert p <= 0.01
+        assert effect > 0.8
+
+    def test_noise_alone_is_not_structure(self):
+        """High noise but no house views must not register as model-specific."""
+        p, _ = model_effect(
+            panel([ALL_IN] * 3, sigma=0.40, repeats=64), rng=np.random.default_rng(0)
+        )
+        assert p > 0.05
+
+    def test_requires_two_models(self):
+        with pytest.raises(ValueError, match="at least 2"):
+            model_effect(panel([ALL_IN]))
+
+    def test_reproducible_given_seed(self):
+        R = panel([ALL_IN, OTHER, THIRD])
+        a = model_effect(R, n_permutations=200, rng=np.random.default_rng(3))
+        b = model_effect(R, n_permutations=200, rng=np.random.default_rng(3))
+        assert a == b
+
+
+class TestCrowdingIndex:
+    def test_separates_the_two_unanimous_cases(self):
+        """THE counterexample from #8: cosine similarity scores both of these
+        1.000, but only one is a crowding event."""
+        assert crowding_index(panel([ALL_IN] * 3)) > 0.8
+        assert crowding_index(panel([UNIFORM] * 3)) < 0.1
+
+    def test_low_under_disagreement(self):
+        assert crowding_index(panel([ALL_IN, OTHER, THIRD])) < 0.2
+
+    def test_bounded(self):
+        for bases in ([ALL_IN] * 3, [UNIFORM] * 3, [ALL_IN, OTHER, THIRD]):
+            assert 0.0 <= crowding_index(panel(bases)) <= 1.0
+
+
+class TestDrift:
+    def test_zero_for_identical(self):
+        assert drift(UNIFORM, UNIFORM) == pytest.approx(0.0)
+
+    def test_positive_when_consensus_moves(self):
+        assert drift(ALL_IN, OTHER) > 1.0
+
+    def test_symmetric(self):
+        assert drift(ALL_IN, UNIFORM) == pytest.approx(drift(UNIFORM, ALL_IN))
+
+    def test_shape_mismatch_raises(self):
+        with pytest.raises(ValueError, match="shape mismatch"):
+            drift([0.5, 0.5], [0.3, 0.3, 0.4])

--- a/tests/test_retail_ai.py
+++ b/tests/test_retail_ai.py
@@ -1,0 +1,110 @@
+"""
+Regression tests for retail AI query -> allocation determinism.
+
+Guards #6: stub_llm_response seeded its RNG from builtin hash(), which Python
+randomizes per process (PEP 456), so mu_retail was irreproducible across runs.
+The determinism test therefore runs in subprocesses -- an in-process test would
+have passed even with the bug.
+"""
+
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+from agents.retail_ai import (
+    InvestorType,
+    RetailQuery,
+    aggregate_retail_strategy,
+    stable_seed,
+    stub_llm_response,
+)
+
+TICKERS = ["AAPL", "MSFT", "NVDA", "TSLA"]
+
+SNIPPET = """
+from agents.retail_ai import RetailQuery, InvestorType, stub_llm_response
+T = ['AAPL', 'MSFT', 'NVDA', 'TSLA']
+q = RetailQuery(InvestorType.{arch}, T, 'Should I buy the dip?', 0.5)
+print(','.join(f'{{x:.10f}}' for x in stub_llm_response(q, T)))
+"""
+
+
+def _run(arch: str) -> str:
+    r = subprocess.run(
+        [sys.executable, "-c", SNIPPET.format(arch=arch)],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert r.returncode == 0, r.stderr
+    return r.stdout.strip()
+
+
+class TestCrossProcessDeterminism:
+    @pytest.mark.parametrize("arch", ["DIY_QUANT", "MEME_TRADER", "PASSIVE_INDEX"])
+    def test_identical_across_processes(self, arch):
+        """The core guard for #6. DIY_QUANT draws from the RNG, so it is the
+        archetype that actually exercised the randomized-hash seed."""
+        assert len({_run(arch) for _ in range(3)}) == 1
+
+
+class TestStableSeed:
+    def test_deterministic(self):
+        assert stable_seed("buy the dip") == stable_seed("buy the dip")
+
+    def test_salt_changes_output(self):
+        assert stable_seed("x", salt=0) != stable_seed("x", salt=1)
+
+    def test_fits_in_uint32(self):
+        assert 0 <= stable_seed("anything") < 2**32
+
+
+class TestSeedOverride:
+    def test_explicit_seed_wins(self):
+        a, b = (
+            stub_llm_response(
+                RetailQuery(InvestorType.DIY_QUANT, TICKERS, ctx, 0.5, seed=99),
+                TICKERS,
+            )
+            for ctx in ("question one", "a totally different question")
+        )
+        np.testing.assert_allclose(a, b)
+
+    def test_different_seeds_differ(self):
+        a, b = (
+            stub_llm_response(
+                RetailQuery(InvestorType.DIY_QUANT, TICKERS, "same", 0.5, seed=s),
+                TICKERS,
+            )
+            for s in (1, 2)
+        )
+        assert not np.allclose(a, b)
+
+    def test_seed_defaults_to_none(self):
+        assert RetailQuery(InvestorType.PASSIVE_INDEX, TICKERS, "c", 0.5).seed is None
+
+
+class TestAllocationContract:
+    @pytest.mark.parametrize("arch", list(InvestorType))
+    def test_is_a_simplex_point(self, arch):
+        """Every archetype must return a valid allocation over the full universe."""
+        alloc = stub_llm_response(
+            RetailQuery(arch, ["AAPL"], "Should I buy the dip?", 0.5), TICKERS
+        )
+        assert alloc.shape == (len(TICKERS),)
+        assert (alloc >= 0).all()
+        np.testing.assert_allclose(alloc.sum(), 1.0, atol=1e-9)
+
+
+class TestMuRetailReproducible:
+    def test_same_queries_same_mu(self):
+        """The property that actually matters: mu_retail is the mean-field
+        quantity behind Component 4c, so it must be reproducible."""
+        qs = [
+            RetailQuery(t, TICKERS, "Should I buy the dip?", 0.5)
+            for t in InvestorType
+        ]
+        np.testing.assert_allclose(
+            aggregate_retail_strategy(qs, TICKERS),
+            aggregate_retail_strategy(qs, TICKERS),
+        )


### PR DESCRIPTION
Supersedes #9 (same metrics module, now with the corpus it operates on). Design discussion in #8.

This is E5's measurement layer: the prompt grid, and the statistics computed over the responses. No API calls, no new dependencies beyond numpy.

**Depends on #7.** The corpus sets `RetailQuery.seed` and uses `stable_seed`, neither of which exists on `main` yet. I'd rather declare that than vendor a duplicate copy of a five-line function.

## `e5/corpus.py` — the audit grid

Enumerates what §1.6 specifies: 5 archetypes × tickers × market conditions × dates.

This is deliberately *not* a wrapper around `simulate_retail_query_distribution`, because that function answers a different question — it samples "what is the retail population asking today," while an audit needs "here is prompt #147, send it to every model on every date, every run." Same archetypes, same stress intuition, different sampling contract. R̂(q) is a *conditional* kernel: comparing models means holding q fixed, and measuring drift means holding q fixed across dates.

`RetailQuery` has no date field, so `CorpusItem` pairs each query with one. Drift is ‖c̄_t − c̄_{t−1}‖ on a fixed prompt set and is uncomputable without it.

`query_id` is derived from the cell coordinates, so it's identical across processes and machines — that's what lets a response recorded today be matched to the same prompt next month. Prompt text is stored as data rather than built by f-string logic, so exact wording is reviewable and citable in the published dataset. Risk tolerance is fixed per archetype rather than sampled, so archetype effects aren't confounded with risk effects.

## `e5/metrics.py` — response-kernel statistics

`consensus` (the empirical c_t), `spread`, `concentration`, `model_effect`, `crowding_index`, `drift`.

A single agreement number can't support E5's claim. Mean pairwise cosine scores these identically at 1.000:

| case | cosine | concentration | crowding |
|---|---|---|---|
| unanimous, all-in one name | 1.000 | 0.889 | 0.889 |
| unanimous, index fund | 1.000 | 0.000 | 0.000 |
| all models differ | — | 0.096 | 0.039 |

Unanimous "buy NVDA" is a crowding event; unanimous "hold an index fund" isn't. Normalized entropy of the mean fails the other way — it rates total disagreement (0.613) above partial agreement (0.355), since disjoint concentrated bets average into a diffuse consensus.

`crowding_index = (1 − spread) · concentration` is the quantity that maps to h in μ_retail = (1−h)μ_idio + h·c_t: high only when models agree *and* the thing agreed on is concentrated.

## The part worth reviewing closely

`model_effect` returns `(p_value, effect_size)` rather than a scalar, after two failed attempts:

First, I permuted model labels on a *pooled* statistic that never reads them — observed and null were mathematically identical, 0.0000 apart on every case. Second, returning `1 − null/observed` alone: under H₀ that ratio fluctuates around 1, so `max(0, ·)` makes it **bimodal**. Across 8 seeds with identical models: `[0.636, 0.0, 0.0, 0.23, 0.589, 0.0, 0.0, 0.0]`. It also doesn't converge — 8/32/128/512 repeats gave 0.636, 0.000, 0.696, 0.047.

The fix is a proper permutation test. The p-value is uniform under H₀ by construction, and the test asserts calibration across 20 seeds rather than trusting one draw. On real house views it hits the B=1000 floor on every seed.

Naming note: `model_effect` measures model-*specific* structure, the opposite of herding — high when platforms hold competing house views. A landscape diagnostic, not ĥ.

## Tests

106 tests total on Python 3.13 / macOS arm64 (50 pre-existing + 56 new across #7, corpus, and metrics). Several assert discrimination between the counterexample cases rather than exact values, so the modules can't regress to an estimator that conflates them. Cross-process determinism is checked via subprocesses for both `query_id` and the stub baseline.

## Next, and the open questions from #8

Harness plan: stub mode + recorded-fixture replay so it stays testable offline under the zero-key policy, with a thin provider interface you'd run on your own keys. I'd rather leave you a reusable instrument than spend on a one-off dataset.

Still useful to know: (1) does the two-statistic decomposition match your intent, or did you want a single ĥ? (2) per-query, per-archetype, or pooled estimation?