### PR TITLE
fix(events): correct covariance uncertainty propagation in groupoid `compose()`

### DIFF
--- a/events/operators.py
+++ b/events/operators.py
@@ -853,10 +853,12 @@ def compose(op1: EventOperator, op2: EventOperator) -> EventOperator:
     A_comp = op1.A_w @ op2.A_w
     b_comp = op1.A_w @ op2.b_w + op1.b_w
     # Uncertainty propagation: Var(A1(A2 s + ε2) + ε1) = A1 Σ2 A1' + Σ1
-    Sigma_comp_sq = op1.Sigma_w @ op1.Sigma_w + op1.A_w @ (op2.Sigma_w @ op2.Sigma_w) @ op1.A_w.T
-    # Take element-wise sqrt to get back to Cholesky-scale
+    Sigma_comp_sq = (
+      op1.Sigma_w @ op1.Sigma_w.T + op1.A_w @ (op2.Sigma_w @ op2.Sigma_w.T) @ op1.A_w.T
+    )
+    # Factorize the composite covariance to recover the lower triangular scale matrix
     Sigma_comp = np.linalg.cholesky(Sigma_comp_sq + 1e-9 * np.eye(Sigma_comp_sq.shape[0]))
-
+  
     return EventOperator(
         name=f"({op1.name}) ∘ ({op2.name})",
         mode=op2.mode,


### PR DESCRIPTION
The uncertainty propagation inside `compose()` computes `Sigma_comp_sq` by squaring `Sigma_w` directly (`Sigma_w @ Sigma_w`) rather than forming the covariance via `Sigma_w @ Sigma_w.T`.

#### Maths
Given affine operators with noise terms $\eta_i = \Sigma_i \epsilon_i$ where $\epsilon_i \sim \mathcal{N}(0, I)$, the covariance of the noise is: $$\operatorname{Cov}(\eta_i) = \Sigma_i \Sigma_i^\top$$

Under composition $T_1 \circ T_2$:
$$T_1(T_2(s)) = A_1 A_2 s + (A_1 b_2 + b_1) + (A_1 \Sigma_2 \epsilon_2 + \Sigma_1 \epsilon_1)$$

Because $\epsilon_1 \perp \epsilon_2$, the covariance of total noise $\eta_{\text{comp}}$ is: $$\operatorname{Cov}(\eta_{\text{comp}}) = \Sigma_1 \Sigma_1^\top + A_1 (\Sigma_2 \Sigma_2^\top) A_1^\top$$